### PR TITLE
Updated loop functions to work with recent OpenGL changes to ARGoS.

### DIFF
--- a/loop_functions/id_loop_functions/id_qtuser_functions.cpp
+++ b/loop_functions/id_loop_functions/id_qtuser_functions.cpp
@@ -23,7 +23,7 @@ void CIDQTUserFunctions::Draw(CFootBotEntity& c_entity) {
     * See also the description in
     * $ argos3 -q foot-bot
     */
-   GetOpenGLWidget().renderText(0.0, 0.0, 0.3,             // position
+   GetQTOpenGLWidget().renderText(0.0, 0.0, 0.3,             // position
                                 c_entity.GetId().c_str()); // text
    /* Restore face culling */
    glEnable(GL_CULL_FACE);

--- a/loop_functions/manualcontrol_loop_functions/manualcontrol_qtuser_functions.cpp
+++ b/loop_functions/manualcontrol_loop_functions/manualcontrol_qtuser_functions.cpp
@@ -25,7 +25,7 @@ CManualControlQTUserFunctions::CManualControlQTUserFunctions() :
 void CManualControlQTUserFunctions::KeyPressed(QKeyEvent* pc_event) {
    /* Make sure that a controller was set */
    if(!m_pcController) {
-      GetOpenGLWidget().KeyPressed(pc_event);
+      GetQTOpenGLWidget().KeyPressed(pc_event);
       return;
    }
    switch(pc_event->key()) {
@@ -51,7 +51,7 @@ void CManualControlQTUserFunctions::KeyPressed(QKeyEvent* pc_event) {
          break;
       default:
          /* Unknown key */
-         GetOpenGLWidget().KeyPressed(pc_event);
+         GetQTOpenGLWidget().KeyPressed(pc_event);
          break;
    }
 }
@@ -62,7 +62,7 @@ void CManualControlQTUserFunctions::KeyPressed(QKeyEvent* pc_event) {
 void CManualControlQTUserFunctions::KeyReleased(QKeyEvent* pc_event) {
    /* Make sure that a controller was set */
    if(!m_pcController) {
-      GetOpenGLWidget().KeyReleased(pc_event);
+      GetQTOpenGLWidget().KeyReleased(pc_event);
       return;
    }
    switch(pc_event->key()) {
@@ -88,7 +88,7 @@ void CManualControlQTUserFunctions::KeyReleased(QKeyEvent* pc_event) {
          break;
       default:
          /* Unknown key */
-         GetOpenGLWidget().KeyReleased(pc_event);
+         GetQTOpenGLWidget().KeyReleased(pc_event);
          break;
    }
 }


### PR DESCRIPTION
Recent changes to ARGoS mean that the argos3-examples code no longer compiles. The proposed changes fix the compilation errors.